### PR TITLE
pgd_attack: Reconcile C&W loss with @carlini's implementation

### DIFF
--- a/pgd_attack.py
+++ b/pgd_attack.py
@@ -32,7 +32,7 @@ class LinfPGDAttack:
                               off_value=0.0,
                               dtype=tf.float32)
       correct_logit = tf.reduce_sum(label_mask * model.pre_softmax, axis=1)
-      wrong_logit = tf.reduce_max((1-label_mask) * model.pre_softmax, axis=1)
+      wrong_logit = tf.reduce_max((1-label_mask) * model.pre_softmax - 1e4*label_mask, axis=1)
       loss = -tf.nn.relu(correct_logit - wrong_logit + 50)
     else:
       print('Unknown loss function. Defaulting to cross-entropy')


### PR DESCRIPTION
Upstream implementation: https://github.com/carlini/nn_robust_attacks/blob/master/l2_attack.py#L90

This subtraction helps select the 'other' class when the logits are negative.