### PR TITLE
Correct architecture description

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ As a reference point, we have seeded the leaderboard with the results of some st
 
 ### The CIFAR10 Model
 
-We used the code published in this repository to produce an adversarially robust model for CIFAR10 classification. The model is a residual convolutional neural network consisting of five residual units and a fully connected layer. This architecture is derived from the "w28-10 wide" variant of the [Tensorflow model repository](https://github.com/tensorflow/models/blob/master/resnet/resnet_model.py).
+We used the code published in this repository to produce an adversarially robust model for CIFAR10 classification. The model is a residual convolutional neural network consisting of five residual units and a fully connected layer. This architecture is derived from the "w32-10 wide" variant of the [Tensorflow model repository](https://github.com/tensorflow/models/blob/master/resnet/resnet_model.py).
 The network was trained against an iterative adversary that is allowed to perturb each pixel by at most `epsilon=8.0`.
 
 The random seed used for training and the trained network weights will be kept secret.


### PR DESCRIPTION
https://github.com/MadryLab/cifar10_challenge/blob/master/model.py#L59-L78

This code is adapted from a the 32-layer ResNet in the Tensorflow models repository.

https://github.com/tensorflow/models/blob/master/research/resnet/resnet_model.py#L88

The upstream code notes that in a w28-10 model, there are 4 num_residual_blocks instead of 5.